### PR TITLE
added some changes that we need for easier development

### DIFF
--- a/db/db.js
+++ b/db/db.js
@@ -1,5 +1,5 @@
 var config      = require('../knexfile.js');
-var env         = 'production';
+var env         = 'development';
 var knex        = require('knex')(config[env]);
 
 module.exports = knex;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "start": "nodemon server/server.js | babel . --watch --out-dir compiled --presets=es2015,react --ignore=node_modules,compiled --source-maps inline"
+    "watch": "babel . --watch --out-dir compiled --presets=es2015,react --ignore=node_modules,compiled --source-maps inline",
+    "start": "nodemon server/server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Instead of following the start server instructions on the README.md, follow these instructions to start your server and do the babel watch. 

Start the babel transpiling in one terminal window with `npm run watch`. This command will not close, so keep it open. In another window, start your server with `npm start`. Again, this will not close and will show all of your console logs.